### PR TITLE
Update config.plist

### DIFF
--- a/EFI/OC/config.plist
+++ b/EFI/OC/config.plist
@@ -221,6 +221,12 @@
 				<data>AQAAAA==</data>
 				<key>hda-gfx</key>
 				<string>onboard-1</string>
+				<key>framebuffer-unifiedmem</key>
+				<data>AAAAgA==</data>
+				<key>framebuffer-stolenmem</key>
+				<data>AAAABA==</data>
+				<key>framebuffer-fbmem</key>
+				<data>AAAAAw==</data>
 			</dict>
 		</dict>
 		<key>Delete</key>


### PR DESCRIPTION
I've enabled 4k and multi-monitor support for the Optiplex 7020 (SFF) by adding the following values to the WhateverGreen (WEG) Device Properties in config.plist: 
- framebuffer-unifiedmem -> data 00000080 
- framebuffer-stolenmem -> data 00000004
- framebuffer-fbmem -> data 00000003

Note this does **not** rely on any unstable kext patching. Credit to you for figuring out what the old 4k azul patch did in the first place, @nicksoph, and @0xd1ab10 for helping me narrow down the proper WEG properties and values to change.

Also, this is my first time doing _anything_ in GitHub, so I apologize in advance and please double check my work!