### PR TITLE
Use correct setting for audio layout

### DIFF
--- a/EFI/OC/config.plist
+++ b/EFI/OC/config.plist
@@ -194,8 +194,8 @@
 		<dict>
 			<key>PciRoot(0x0)/Pci(0x1b,0x0)</key>
 			<dict>
-				<key>alc-layout-id</key>
-				<integer>16</integer>
+				<key>layout-id</key>
+				<data>EAAAAA==</data>
 			</dict>
 			<key>PciRoot(0x0)/Pci(0x2,0x0)</key>
 			<dict>


### PR DESCRIPTION
According to the docs https://dortania.github.io/OpenCore-Post-Install/universal/audio.html#making-layout-id-more-permanent we should really be using `layout-id`.

This also fixes an error on the startup logs. Unfortunately it doesn't fix the rear audio.