### PR TITLE
DeviceProperties update to enable 4k, remove userspace dependencies for possible Big Sur

### DIFF
--- a/EFI/OC/config.plist
+++ b/EFI/OC/config.plist
@@ -211,22 +211,22 @@
 				<data>FAAAAA==</data>
 				<key>enable-dpcd-max-link-rate-fix</key>
 				<data>AQAAAA==</data>
-				<key>enable-lspcon-support</key>
-				<data>AQAAAA==</data>
 				<key>enable-max-pixel-clock-override</key>
 				<data>AQAAAA==</data>
-				<key>framebuffer-con0-alldata</key>
-				<data>AAAIAAIAAAAwAAAAAQUJAAAEAAAHAQAAAgQKAAAEAAAHAQAA</data>
+				<key>enable-lspcon-support</key>
+				<data>AQAAAA==</data>
+				<key>framebuffer-con1-enable</key>
+				<data>AQAAAA==</data>
 				<key>framebuffer-con0-enable</key>
-				<integer>1</integer>
+				<data>AQAAAA==</data>
+				<key>framebuffer-portcount</key>
+				<data>AgAAAA==</data>
 				<key>framebuffer-fbmem</key>
 				<data>AAAAAw==</data>
 				<key>framebuffer-patch-enable</key>
 				<data>AQAAAA==</data>
-				<key>framebuffer-portcount</key>
-				<data>BAAAAA==</data>
 				<key>framebuffer-stolenmem</key>
-				<data>AAAABA==</data>
+				<data>AAAACg==</data>
 				<key>framebuffer-unifiedmem</key>
 				<data>AAAAgA==</data>
 				<key>hda-gfx</key>

--- a/EFI/OC/config.plist
+++ b/EFI/OC/config.plist
@@ -48,7 +48,8 @@
 			</dict>
 		</array>
 		<key>Delete</key>
-		<array/>
+		<array>
+		</array>
 		<key>Patch</key>
 		<array>
 			<dict>
@@ -147,7 +148,8 @@
 	<key>Booter</key>
 	<dict>
 		<key>MmioWhitelist</key>
-		<array/>
+		<array>
+		</array>
 		<key>Quirks</key>
 		<dict>
 			<key>AllowRelocationBlock</key>
@@ -205,14 +207,24 @@
 				<data>EgQAAA==</data>
 				<key>disable-external-gpu</key>
 				<data>AQAAAA==</data>
-				<key>disable-hdmi-patches</key>
+				<key>dpcd-max-link-rate</key>
+				<data>FAAAAA==</data>
+				<key>enable-dpcd-max-link-rate-fix</key>
 				<data>AQAAAA==</data>
-				<key>enable-hdmi20</key>
+				<key>enable-lspcon-support</key>
 				<data>AQAAAA==</data>
+				<key>enable-max-pixel-clock-override</key>
+				<data>AQAAAA==</data>
+				<key>framebuffer-con0-alldata</key>
+				<data>AAAIAAIAAAAwAAAAAQUJAAAEAAAHAQAAAgQKAAAEAAAHAQAA</data>
+				<key>framebuffer-con0-enable</key>
+				<integer>1</integer>
 				<key>framebuffer-fbmem</key>
 				<data>AAAAAw==</data>
 				<key>framebuffer-patch-enable</key>
 				<data>AQAAAA==</data>
+				<key>framebuffer-portcount</key>
+				<data>BAAAAA==</data>
 				<key>framebuffer-stolenmem</key>
 				<data>AAAABA==</data>
 				<key>framebuffer-unifiedmem</key>
@@ -358,7 +370,8 @@
 			</dict>
 		</array>
 		<key>Block</key>
-		<array/>
+		<array>
+		</array>
 		<key>Emulate</key>
 		<dict>
 			<key>Cpuid1Data</key>
@@ -373,7 +386,8 @@
 			<string></string>
 		</dict>
 		<key>Patch</key>
-		<array/>
+		<array>
+		</array>
 		<key>Quirks</key>
 		<dict>
 			<key>AppleCpuPmCfgLock</key>
@@ -426,7 +440,8 @@
 	<key>Misc</key>
 	<dict>
 		<key>BlessOverride</key>
-		<array/>
+		<array>
+		</array>
 		<key>Boot</key>
 		<dict>
 			<key>ConsoleAttributes</key>
@@ -472,7 +487,8 @@
 			<integer>3</integer>
 		</dict>
 		<key>Entries</key>
-		<array/>
+		<array>
+		</array>
 		<key>Security</key>
 		<dict>
 			<key>AllowNvramReset</key>
@@ -793,7 +809,8 @@
 			<false/>
 		</dict>
 		<key>ReservedMemory</key>
-		<array/>
+		<array>
+		</array>
 	</dict>
 </dict>
 </plist>


### PR DESCRIPTION
Config.plist for testing Big Sur 4k/60 compatibility. Tested on Catalina and 4k/60 working with the DeviceProperties in this branch. Please don't merge, requires stability testing and Big Sur testing but I figured this would be the easiest way for folks to test/review.

Additions to DeviceProperties:

- Dpcd-max-link-rate - Choose a DPCD maximum link rate for your display, where 4K=0x14 (default) or 1080p=0x0a. Related to driving 4k displays over display port (something to do with the link speed to the monitor?) seems relevant
- enable-lspcon-support - to enable DisplayPort to HDMI 2.0 output on some platforms with Intel IGPU
- enable-max-pixel-clock-override - discussed previously as an alternative to problematic enable-hdmi20 userspace patch
- framebuffer-con0-alldata - values added in suggestion/discussion on reddit (I have no current understanding of what these values do).
- framebuffer-con0-enable - enables these con0 properties

Removed:
- enable-hdmi20 - userspace patch previously required for 4k

No changes to previous FrameBuffer settings (e.g., IDs, fbmem, etc.)